### PR TITLE
Revert "fix: カテゴリ登録した内容が編集画面に表示されないバグ修正 "

### DIFF
--- a/View/Elements/edit_form_categories.ctp
+++ b/View/Elements/edit_form_categories.ctp
@@ -32,10 +32,10 @@
 				</button>
 			</div>
 
-			<input type="hidden" name="data[Categories][{{$index}}][Category][id]" ng-value="c.category.id">
+			<input type="hidden" name="data[Categories][{{$index}}][Category][id]" ng-value="c.Category.id">
 			<input type="hidden" name="data[Categories][{{$index}}][CategoryOrder][weight]" ng-value="{{$index + 1}}">
 			<input type="text" name="data[Categories][{{$index}}][CategoriesLanguage][name]"
-					ng-model="c.categoriesLanguage.name" class="form-control" required autofocus>
+					ng-model="c.CategoriesLanguage.name" class="form-control" required autofocus>
 
 			<div class="input-group-btn">
 				<button type="button" class="btn btn-default" tooltip="<?php echo __d('net_commons', 'Delete'); ?>"


### PR DESCRIPTION
Reverts NetCommons3/Categories#53

https://github.com/NetCommons3/NetCommons3/issues/1343

ブログや、リンクリストなど他のプラグインで、同様の不具合が出ていました。
修正を元に戻します。

施設予約は、カテゴリからエレメントをコピーして、カテゴリ編集画面を作成していました。
カテゴリプラグインを参考に、別途修正します。
