### PR TITLE
fix: カテゴリドロップダウンでNoticeが発生することがあるのを修正

### DIFF
--- a/View/Elements/dropdown_toggle_category.ctp
+++ b/View/Elements/dropdown_toggle_category.ctp
@@ -16,7 +16,7 @@
 			<div class="clearfix">
 				<div class="pull-left nc-category-ellipsis">
 					<?php if (isset($currentCategoryId)) : ?>
-						<?php echo h($options['categories'][$currentCategoryId]['name']); ?>
+						<?php echo h($options['categories'][$currentCategoryId]['name'] ?? ''); ?>
 					<?php else : ?>
 						<?php echo h($options['categories']['0']['name']); ?>
 					<?php endif; ?>


### PR DESCRIPTION
fix: カテゴリドロップダウンで$options['categories']にない$currentCategoryIdが指定されるとNoticeになるのを修正 Refs https://github.com/researchmap/RmNetCommons3/issues/2667